### PR TITLE
Added a Dockerized build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.dockerignore
+Dockerfile
+/.git*

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildmode=default -ldflags="
 FROM $BASE_IMAGE
 
 ARG USER="nobody"
-ARG GROUP="nobody"
+ARG GROUP="nogroup"
 
 COPY --from=builder --chown=${USER}:${GROUP} /go/src/github.com/daniel-widrick/mcPortKnock/mcPortKnock /mcPortKnock
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,6 @@ COPY --from=builder --chown=${USER}:${GROUP} /go/src/github.com/daniel-widrick/m
 USER ${USER}
 
 WORKDIR /mcPortKnock
+EXPOSE 25565
+
 ENTRYPOINT ["/mcPortKnock/mcPortKnock"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+ARG BASE_IMAGE=debian:11-slim
+ARG GO_IMAGE=golang:latest
+FROM $GO_IMAGE as builder
+
+# NOTE: This arg will be populated by docker buildx
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG TARGETARCH
+
+RUN mkdir -p /go/src/github.com/daniel-widrick/mcPortKnock/
+WORKDIR /go/src/github.com/daniel-widrick/mcPortKnock/
+COPY . /go/src/github.com/daniel-widrick/mcPortKnock/
+
+ARG GO111MODULE="on"
+ENV GO111MODULE=${GO111MODULE}
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildmode=default -ldflags="-s -w"
+
+FROM $BASE_IMAGE
+
+ARG USER="nobody"
+ARG GROUP="nobody"
+
+COPY --from=builder --chown=${USER}:${GROUP} /go/src/github.com/daniel-widrick/mcPortKnock/mcPortKnock /mcPortKnock
+
+USER ${USER}
+
+ENTRYPOINT ["/mcPortKnock"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,10 @@ FROM $BASE_IMAGE
 ARG USER="nobody"
 ARG GROUP="nogroup"
 
-COPY --from=builder --chown=${USER}:${GROUP} /go/src/github.com/daniel-widrick/mcPortKnock/mcPortKnock /mcPortKnock
+RUN mkdir /mcPortKnock && chown ${USER}:${GROUP} /mcPortKnock
+COPY --from=builder --chown=${USER}:${GROUP} /go/src/github.com/daniel-widrick/mcPortKnock/mcPortKnock /mcPortKnock/mcPortKnock
 
 USER ${USER}
 
-ENTRYPOINT ["/mcPortKnock"]
+WORKDIR /mcPortKnock
+ENTRYPOINT ["/mcPortKnock/mcPortKnock"]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/daniel-widrick/mcPortKnock
+
+go 1.17
+
+require (
+)


### PR DESCRIPTION
Adds a multi-stage Dockerized build-from-source of `mcPortKnock`.

```
docker build -t localbuild/mc-port-knock .
docker run -it --rm -v $(pwd)/config.json:/config.json localbuild/mc-port-knock
```

This provides an amd64 arch statically-linked binary.  I tested and you can run this from a `scratch` image if desired (you need to run as `root` or copy a `passwd` file over in that case).  By-default this build goes-on to add `mcPortKnock` to a `debian:11-slim` image (`BASE` is configurable build-arg).

Other than the built binary, the final image on its own isn't super valuable, as there's no local MC server installed and possibly not the commands to operate on a remote one, but this image could serve as a base.  With a little more work (mostly around environment-as-config) this makes a `mcPortKnock` image that can be hosted in a container environment - this can also be done as-is with a volume-mount for `config.json`.